### PR TITLE
Make ForcesInput an inner class of the input model

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ inp = mmic_md.InputMD(
 ```
 
 Examples for the Parameters:
+
 *METHOD_FOR_LONGRANGE_INTERACTION*  "PME"
+
 *METHOD_FOR_SHORT_INTERACTION*  "cut-off"
+
 *T_COUPLE_METHOD*  "Berendsen"
+
 *P_COUPLE_METHOD*  "Parrinello-Rahman"
 
 ## Runing MD Simulation

--- a/README.md
+++ b/README.md
@@ -27,33 +27,9 @@ inp = mmic_md.InputMD(
     schema_name=SCHEMA_NAME,
     schema_version=SCHEMA_VERSION,
     system={mol: ff},
-    boundary=(
-        "periodic",
-        "periodic",
-        "periodic",
-        "periodic",
-        "periodic",
-        "periodic",
-    ),
-    max_steps=TOTAL_STEP_NUMBER,
-    step_size=STEP_SIZE,
-    method="md",
-    long_forces={"method": METHOD_FOR_LONGRANGE_INTERACTION},
-    short_forces={"method": METHOD_FOR_SHORT_INTERACTION},
-    temp_couple={"method": T_COUPLE_METHOD, "ref_t": REFERENCE_T},
-    press_couple={"method": P_COUPLE_METHOD},
+    ...
 )	
 ```
-
-Examples for the Parameters:
-
-*METHOD_FOR_LONGRANGE_INTERACTION*  "PME"
-
-*METHOD_FOR_SHORT_INTERACTION*  "cut-off"
-
-*T_COUPLE_METHOD*  "Berendsen"
-
-*P_COUPLE_METHOD*  "Parrinello-Rahman"
 
 ## Runing MD Simulation
 ```python

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 MINT
 ==============================
+
+# Molecular Dynamics Component
+
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/mmic_md/workflows/CI/badge.svg)](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/mmic_md/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/MINT/branch/master/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/MINT/branch/master)
+[![GitHub Actions Build Status](https://github.com/RlyehAD/mmic_md/workflows/CI/badge.svg)](https://github.com/RlyehAD/mmic_md/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/RlyehAD/mmic_md/branch/master/graph/badge.svg)](https://codecov.io/gh/RlyehAD/mmic_md/branch/master)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/RlyehAD/mmic_md.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RlyehAD/mmic_md/context:python)
 
 
 The Generic component for running MD simulations using MMIC

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pot_energy = outp.observables["pot_energy"]
 
 ### Copyright
 
-Copyright (c) 2021, Xu Guo
+Copyright (c) 2021,  Xu Guo, Andrew Abi-Mansour
 
 
 #### Acknowledgements

--- a/README.md
+++ b/README.md
@@ -8,8 +8,65 @@ MINT
 [![codecov](https://codecov.io/gh/RlyehAD/mmic_md/branch/master/graph/badge.svg)](https://codecov.io/gh/RlyehAD/mmic_md/branch/master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/RlyehAD/mmic_md.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RlyehAD/mmic_md/context:python)
 
+This is part of the [MolSSI](http://molssi.org) Molecular Mechanics Interoperable Components ([MMIC](https://github.com/MolSSI/mmic)) project. This package provides a strategy component for running Molecular Dynamics simulations for systems composed by molecules and their forcefields.
 
-The Generic component for running MD simulations using MMIC
+## Preparing Input
+```python
+# Import moleucule and forcefield models
+from mmelemental.models import Molecule, ForceField
+
+# Import MD component
+import mmic_md
+
+# Construct molecule and forcefield objects
+mol = Molecule.from_file(path_to_file)
+ff = ForceField.from_file(path_to_file)
+
+# Construct input data model from molecule and forcefield objects
+inp = mmic_md.InputMD(
+    schema_name=SCHEMA_NAME,
+    schema_version=SCHEMA_VERSION,
+    system={mol: ff},
+    boundary=(
+        "periodic",
+        "periodic",
+        "periodic",
+        "periodic",
+        "periodic",
+        "periodic",
+    ),
+    max_steps=TOTAL_STEP_NUMBER,
+    step_size=STEP_SIZE,
+    method="md",
+    long_forces={"method": METHOD_FOR_LONGRANGE_INTERACTION},
+    short_forces={"method": METHOD_FOR_SHORT_INTERACTION},
+    temp_couple={"method": T_COUPLE_METHOD, "ref_t": REFERENCE_T},
+    press_couple={"method": P_COUPLE_METHOD},
+)	
+```
+
+Examples for the Parameters:
+*METHOD_FOR_LONGRANGE_INTERACTION*  "PME"
+*METHOD_FOR_SHORT_INTERACTION*  "cut-off"
+*T_COUPLE_METHOD*  "Berendsen"
+*P_COUPLE_METHOD*  "Parrinello-Rahman"
+
+## Runing MD Simulation
+```python
+# Import strategy compoent for runing MD simulation
+from mmic_md.components import MDComponent
+
+# Run MD Simulation
+outp = MDComponent.compute(inp)
+```
+
+## Extracting Output
+```python
+# Extract the potential energy 
+pot_energy = outp.observables["pot_energy"]
+...
+```
+
 
 ### Copyright
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,6 +17,6 @@ dependencies:
     - pydantic
     - qcelemental
     - mmic
-    - git+https://github.com/MolSSI/mmelemental.git
+    - mmelemental
     - git+https://github.com/MolSSI/cmselemental.git
     - git+https://github.com/MolSSI/mm_data.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,6 +1,7 @@
 name: test
 channels:
   - conda-forge
+  
   - defaults
 dependencies:
     # Base depends
@@ -16,7 +17,7 @@ dependencies:
   - pip:
     - pydantic
     - qcelemental
-    - mmic
-    - mmelemental
     - cmselemental
+    - mmelemental
+    - mmic
     - git+https://github.com/MolSSI/mm_data.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,5 +18,5 @@ dependencies:
     - qcelemental
     - mmic
     - mmelemental
-    - git+https://github.com/MolSSI/cmselemental.git
+    - cmselemental
     - git+https://github.com/MolSSI/mm_data.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,5 +19,5 @@ dependencies:
     - qcelemental
     - cmselemental
     - mmelemental
-    - mmic
     - git+https://github.com/MolSSI/mm_data.git
+    - mmic

--- a/mmic_md/components/sample_component.py
+++ b/mmic_md/components/sample_component.py
@@ -6,6 +6,8 @@ from typing import List, Tuple, Optional
 
 # Import the generic i.e. starting component from MMIC
 from mmic.components.blueprints.generic_component import GenericComponent
+from mmic.components.blueprints import StrategyComponent
+from cmselemental.util.decorators import classproperty
 
 from ..models.input import MDInput
 from ..models.output import MDOutput
@@ -14,20 +16,29 @@ from ..models.output import MDOutput
 __all__ = ["MDComponent"]
 
 
-class MDComponent(GenericComponent):
+class MDComponent(StrategyComponent):
 	""" A sample component that reads in a Molecule and returns a ForceField object. """
 
-	@classmethod
+	@classproperty
 	def input(cls):
 		return MDInput
 
-	@classmethod
+	@@classproperty
 	def output(cls):
 		return MDOutput
 
+    @classproperty
+    def version(cls) -> str:
+        """Finds program, extracts version, returns normalized version string.
+        Returns
+        -------
+        str
+            Return a valid, safe python version string.
+        """
+        return ""
 
-	@property
-	def supported_comps(self) -> Set[str]:
+	@classproperty
+	def tactic_comps(self) -> Set[str]:
 		"""Returns the supported components e.g. set(['mmic_mda',...]).
 		Returns
 		-------

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -1,7 +1,7 @@
 from cmselemental.models.procedures import ProcInput
 from mmelemental.models.base import ProtoModel
 from mmelemental.models import Molecule
-from mmelemental.models.forcefield import ForceField#, ForcesInput
+from mmelemental.models.forcefield import ForceField  # , ForcesInput
 from mmelemental.models.collect import TrajInput
 from pydantic import Field, validator
 from typing import Optional, Dict, List, Tuple, Any, Union
@@ -10,100 +10,101 @@ __all__ = ["MDInput", "ForcesInput"]
 
 
 class ForcesInput(ProtoModel):
-	method: str = Field(..., description="The algorithm used to compute the force. e.g. PME")
+    method: str = Field(
+        ..., description="The algorithm used to compute the force. e.g. PME"
+    )
 
-	cutoff: Optional[float] = Field(None, description="The cut-off distance")
+    cutoff: Optional[float] = Field(None, description="The cut-off distance")
 
-	cutoff_units: Optional[str] = Field("angstrom", description="The unit of cutoff distance")
+    cutoff_units: Optional[str] = Field(
+        "angstrom", description="The unit of cutoff distance"
+    )
+
 
 class MDInput(ProcInput):
-	"""Basic input model for MD run."""
+    """Basic input model for MD run."""
 
-	# System fields
-	molecule: Dict[str, Molecule] = Field(
-		...,
-		description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
-		"Example: mol = {'ligand': Molecule, 'receptor': Molecule, 'solvent': Molecule}.",
-	)
-	forcefield: Dict[str, ForceField] = Field(
-		...,
-		description='Forcefield object(s) or name(s) for every Molecule defined in "mol".',
-	)
-	cell: Optional[
-		Union[
-			Tuple[float, float],
-			Tuple[float, float, float, float],
-			Tuple[float, float, float, float, float, float],
-		]
-	] = Field(
-		None,
-		description="Cell dimensions in the form: ((xmin, ymin, ...), (xmax, ymax, ...))",
-	)
-	boundary: Union[
-		Tuple[str, str],
-		Tuple[str, str, str, str],
-		Tuple[str, str, str, str, str, str],
-	] = Field(
-		...,
-		description="Boundary conditions in all dimensions e.g. (periodic, periodic) imposes periodic boundaries in 1D.",
-	)
-	
-	# I/O fields
-	trajectory: Optional[Dict[str, TrajInput]] = Field(
-		None,
-		description="Trajectories to write for quantity 'key' every 'value' steps. e.g. {'geometry_freq': 10, 'velocities_freq': 100, 'forces_freq': 50} "
-		"produces 3 trajectory objects storing positions every 10 steps, velocities, every 100 steps, and forces every 50 steps.",
-	)
+    # System fields
+    molecule: Dict[str, Molecule] = Field(
+        ...,
+        description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
+        "Example: mol = {'ligand': Molecule, 'receptor': Molecule, 'solvent': Molecule}.",
+    )
+    forcefield: Dict[str, ForceField] = Field(
+        ...,
+        description='Forcefield object(s) or name(s) for every Molecule defined in "mol".',
+    )
+    cell: Optional[
+        Union[
+            Tuple[float, float],
+            Tuple[float, float, float, float],
+            Tuple[float, float, float, float, float, float],
+        ]
+    ] = Field(
+        None,
+        description="Cell dimensions in the form: ((xmin, ymin, ...), (xmax, ymax, ...))",
+    )
+    boundary: Union[
+        Tuple[str, str], Tuple[str, str, str, str], Tuple[str, str, str, str, str, str]
+    ] = Field(
+        ...,
+        description="Boundary conditions in all dimensions e.g. (periodic, periodic) imposes periodic boundaries in 1D.",
+    )
 
-	# Global fields
-	max_steps: int = Field(
-		None, description="Max number of optimization steps to perform."
-	)
-	step_size: float = Field(None, description="Step size for constant step marching.")
-	step_size_units: Optional[str] = Field(
-		None,
-		description="Step size unit. Any unit supported by pint is allowed. If not defined, it's set to fs",
-	)
+    # I/O fields
+    trajectory: Optional[Dict[str, TrajInput]] = Field(
+        None,
+        description="Trajectories to write for quantity 'key' every 'value' steps. e.g. {'geometry_freq': 10, 'velocities_freq': 100, 'forces_freq': 50} "
+        "produces 3 trajectory objects storing positions every 10 steps, velocities, every 100 steps, and forces every 50 steps.",
+    )
 
-	# Algorithmic fields
-	method: str = Field(
-		None,
-		description="The integrator used for MD simulation. e.g. 'md-vv'",
-	)
+    # Global fields
+    max_steps: int = Field(
+        None, description="Max number of optimization steps to perform."
+    )
+    step_size: float = Field(None, description="Step size for constant step marching.")
+    step_size_units: Optional[str] = Field(
+        None,
+        description="Step size unit. Any unit supported by pint is allowed. If not defined, it's set to fs",
+    )
 
-	# Output control
-	freq_write: Optional[Dict[str, int]] = Field(
-		None,
-		description="The args used to set up the frequency to wirite the system properties such as energies and forces. Requires users to specify according to the engine they choose"
-		)
+    # Algorithmic fields
+    method: str = Field(
+        None, description="The integrator used for MD simulation. e.g. 'md-vv'"
+    )
 
+    # Output control
+    freq_write: Optional[Dict[str, int]] = Field(
+        None,
+        description="The args used to set up the frequency to wirite the system properties such as energies and forces. Requires users to specify according to the engine they choose",
+    )
 
-	# Bonded interaction
-	unconstrained_start: str = Field(
-		None,
-		description="To determine if constraints are applied to the initial configuration. It's no by default",
-	)  # May be deleted
-	constraint_method: str = Field(
-		None,
-		description="The algorithm used for constranits. e.g. 'SHAKE'",
-	)
-	constraints: str = Field(
-		None,
-		description="The bonds that are constrained",
-	)  # May be replaced by bond_const
+    # Bonded interaction
+    unconstrained_start: str = Field(
+        None,
+        description="To determine if constraints are applied to the initial configuration. It's no by default",
+    )  # May be deleted
+    constraint_method: str = Field(
+        None, description="The algorithm used for constranits. e.g. 'SHAKE'"
+    )
+    constraints: str = Field(
+        None, description="The bonds that are constrained"
+    )  # May be replaced by bond_const
 
-	# Nonbonded interaction
-	short_forces: ForcesInput = Field(
-		..., description="Algorithms for computing short-range forces."
-	)  
+    # Nonbonded interaction
+    short_forces: ForcesInput = Field(
+        ..., description="Algorithms for computing short-range forces."
+    )
 
-	long_forces: ForcesInput = Field(
-		..., description="Algorithms for computing long-range forces."
-	)
-	#cut_off: str = Field(..., description="Neighbor searching algorithm")
+    long_forces: ForcesInput = Field(
+        ..., description="Algorithms for computing long-range forces."
+    )
+    # cut_off: str = Field(..., description="Neighbor searching algorithm")
 
-	# Temperature and pressure coupling
-	Tcoupl_arg: Optional[Dict[str, Any]] = Field(None, description="Temperature coupling args")
-	Pcoupl_arg: Optional[Dict[str, Any]] = Field(None, description="Pressure coupling args")
-
-
+    # Temperature and pressure coupling
+    Tcoupl_arg: Optional[Dict[str, Any]] = Field(
+        None, description="Temperature coupling args"
+    )
+    Pcoupl_arg: Optional[Dict[str, Any]] = Field(
+        None, description="Pressure coupling args"
+    )

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -63,6 +63,7 @@ class InputMD(InputProc):
     """Basic input model for MD run."""
 
     # System fields
+    """
     molecule: Dict[str, Molecule] = Field(
         ...,
         description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
@@ -71,6 +72,11 @@ class InputMD(InputProc):
     forcefield: Dict[str, ForceField] = Field(
         ...,
         description='Forcefield object(s) or name(s) for every Molecule defined in "mol".',
+    )
+    """
+    system: Dict[Molecule, ForceField] = Field(
+        ...,
+        description="A mapping of Molecule to its corresponding ForceField object(s).",
     )
     cell: Optional[
         Union[

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -1,11 +1,11 @@
-from cmselemental.models.procedures import ProcInput
+from cmselemental.models.procedures import InputProc
 from mmelemental.models.base import ProtoModel
 from mmelemental.models import Molecule
 from mmelemental.models.forcefield import ForceField
 from pydantic import Field, validator
 from typing import Optional, Dict, List, Tuple, Any, Union
 
-__all__ = ["MDInput"]
+__all__ = ["InputMD"]
 
 
 class InputForces(ProtoModel):

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -1,15 +1,14 @@
 from cmselemental.models.procedures import ProcInput
 from mmelemental.models.base import ProtoModel
 from mmelemental.models import Molecule
-from mmelemental.models.forcefield import ForceField  # , ForcesInput
-from mmelemental.models.collect import TrajInput
+from mmelemental.models.forcefield import ForceField
 from pydantic import Field, validator
 from typing import Optional, Dict, List, Tuple, Any, Union
 
-__all__ = ["MDInput", "ForcesInput"]
+__all__ = ["MDInput"]
 
 
-class ForcesInput(ProtoModel):
+class InputForces(ProtoModel):
     method: str = Field(
         ..., description="The algorithm used to compute the force. e.g. PME"
     )
@@ -20,8 +19,40 @@ class ForcesInput(ProtoModel):
         "angstrom", description="The unit of cutoff distance"
     )
 
+        
+class InputTraj(ProtoModel):
+    geometry_freq: Optional[int] = Field(
+        None, description="Every number of steps geometry are saved."
+    )
+    geometry_units: Optional[str] = Field(
+        "angstrom",
+        description="Units for atomic geometry. Defaults to Angstroms.",
+        dimensionality=LENGTH_DIM,
+    )
+    velocities_freq: Optional[int] = Field(
+        None,
+        description="Save velocities every 'velocities_freq' steps.",
+    )
+    velocities_units: Optional[str] = Field(
+        "angstrom/fs",
+        description="Units for atomic velocities. Defaults to Angstroms/femtoseconds.",
+        dimensionality=LENGTH_DIM / TIME_DIM,
+    )
+    forces_freq: Optional[int] = Field(
+        None, description="Every number of steps velocities are saved."
+    )
+    forces_units: Optional[str] = Field(
+        "kJ/(mol*angstrom)",
+        description="Units for atomic forces. Defaults to KiloJoules/mol.Angstroms.",
+        dimensionality=MASS_DIM * LENGTH_DIM / (SUBS_DIM * TIME_DIM ** 2),
+    )
+    freq: Optional[int] = Field(
+        None,
+        description="Every number of steps geometry, velocities, and/or forces are saved.",
+    )
+        
 
-class MDInput(ProcInput):
+class InputMD(InputProc):
     """Basic input model for MD run."""
 
     # System fields
@@ -52,7 +83,7 @@ class MDInput(ProcInput):
     )
 
     # I/O fields
-    trajectory: Optional[Dict[str, TrajInput]] = Field(
+    trajectory: Optional[Dict[str, InputTraj]] = Field(
         None,
         description="Trajectories to write for quantity 'key' every 'value' steps. e.g. {'geometry_freq': 10, 'velocities_freq': 100, 'forces_freq': 50} "
         "produces 3 trajectory objects storing positions every 10 steps, velocities, every 100 steps, and forces every 50 steps.",
@@ -92,19 +123,19 @@ class MDInput(ProcInput):
     )  # May be replaced by bond_const
 
     # Nonbonded interaction
-    short_forces: ForcesInput = Field(
-        ..., description="Algorithms for computing short-range forces."
+    short_forces: Optional[InputForces] = Field(
+        None, description="Schema model for computing short-range forces."
     )
 
-    long_forces: ForcesInput = Field(
-        ..., description="Algorithms for computing long-range forces."
+    long_forces: Optional[InputForces] = Field(
+        None, description="Schema model for computing long-range forces."
     )
     # cut_off: str = Field(..., description="Neighbor searching algorithm")
 
     # Temperature and pressure coupling
-    Tcoupl_arg: Optional[Dict[str, Any]] = Field(
+    temp_couple: Optional[Dict[str, Any]] = Field(
         None, description="Temperature coupling args"
     )
-    Pcoupl_arg: Optional[Dict[str, Any]] = Field(
+    press_couple: Optional[Dict[str, Any]] = Field(
         None, description="Pressure coupling args"
     )

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -61,18 +61,8 @@ class InputTraj(ProtoModel):
 
 class InputMD(InputProc):
     """Basic input model for MD run."""
-
-    # System fields
     """
-    molecule: Dict[str, Molecule] = Field(
-        ...,
-        description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
-        "Example: mol = {'ligand': Molecule, 'receptor': Molecule, 'solvent': Molecule}.",
-    )
-    forcefield: Dict[str, ForceField] = Field(
-        ...,
-        description='Forcefield object(s) or name(s) for every Molecule defined in "mol".',
-    )
+    # System fields
     """
     system: Dict[Molecule, ForceField] = Field(
         ...,

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -1,12 +1,20 @@
 from cmselemental.models.procedures import ProcInput
+from mmelemental.models.base import ProtoModel
 from mmelemental.models import Molecule
-from mmelemental.models.forcefield import ForceField, ForcesInput
+from mmelemental.models.forcefield import ForceField#, ForcesInput
 from mmelemental.models.collect import TrajInput
 from pydantic import Field, validator
 from typing import Optional, Dict, List, Tuple, Any, Union
 
-__all__ = ["MDInput"]
+__all__ = ["MDInput", "ForcesInput"]
 
+
+class ForcesInput(ProtoModel):
+	method: str = Field(..., description="The algorithm used to compute the force. e.g. PME")
+
+	cutoff: Optional[float] = Field(None, description="The cut-off distance")
+
+	cutoff_units: Optional[str] = Field("angstrom", description="The unit of cutoff distance")
 
 class MDInput(ProcInput):
 	"""Basic input model for MD run."""
@@ -69,33 +77,6 @@ class MDInput(ProcInput):
 		description="The args used to set up the frequency to wirite the system properties such as energies and forces. Requires users to specify according to the engine they choose"
 		)
 
-	"""
-	F_xout: float = Field(
-		Optional,
-		description="The frequency for the simulation to write a frame of coordinates",
-	)
-	F_vout: float = Field(
-		Optional,
-		description="The frequency for the simulation to write the velocities",
-	)
-	F_eout: float = Field(
-		Optional,
-		description="The frequency for the simulation to write the energies",
-	)
-	F_fout: float = Field(
-		Optional,
-		description="The frequency for the simulation to write the forces",
-	)
-	# A F for log file output?
-	F_stdout: float = Field(
-		Optional,
-		description="The frequecy for writing an standard output including info of T, P, E, and so on",
-	)
-	F_unit: str = Field(
-		Optional,
-		description="The unit for the frequencies to write coordinates, velocities, and energies",
-	)  # May be deleted
-	"""
 
 	# Bonded interaction
 	unconstrained_start: str = Field(
@@ -124,4 +105,5 @@ class MDInput(ProcInput):
 	# Temperature and pressure coupling
 	Tcoupl_arg: Optional[Dict[str, Any]] = Field(None, description="Temperature coupling args")
 	Pcoupl_arg: Optional[Dict[str, Any]] = Field(None, description="Pressure coupling args")
+
 

--- a/mmic_md/models/input.py
+++ b/mmic_md/models/input.py
@@ -2,6 +2,12 @@ from cmselemental.models.procedures import InputProc
 from mmelemental.models.base import ProtoModel
 from mmelemental.models import Molecule
 from mmelemental.models.forcefield import ForceField
+from mmelemental.util.units import (
+    LENGTH_DIM,
+    MASS_DIM,
+    TIME_DIM,
+    SUBS_DIM,
+)
 from pydantic import Field, validator
 from typing import Optional, Dict, List, Tuple, Any, Union
 
@@ -16,7 +22,8 @@ class InputForces(ProtoModel):
     cutoff: Optional[float] = Field(None, description="The cut-off distance")
 
     cutoff_units: Optional[str] = Field(
-        "angstrom", description="The unit of cutoff distance"
+        "angstrom", description="The unit of cutoff distance",
+        dimensionality=LENGTH_DIM,
     )
 
         

--- a/mmic_md/models/output.py
+++ b/mmic_md/models/output.py
@@ -1,7 +1,7 @@
 from cmselemental.models.procedures import OutputProc
 from .input import InputMD
 from mmelemental.models import Molecule
-from mmelemental.models.collect import Ensemble, Trajectory
+from mmelemental.models.collect import Trajectory
 from pydantic import Field
 from typing import Optional, Dict, List, Union
 
@@ -16,11 +16,6 @@ class OutputMD(OutputProc):
         ...,
         description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
         "Example: mol = {'ligand': Molecule, 'receptor': Molecule, 'solvent': Molecule}.",
-    )
-    ensemble: Optional[Dict[str, Ensemble]] = Field(
-        None,
-        description="Ensemble output for a series of microstates of molecules. "
-        "See the :class:``Ensemble`` class.",
     )
     trajectory: Optional[Dict[str, Trajectory]] = Field(
         None,

--- a/mmic_md/models/output.py
+++ b/mmic_md/models/output.py
@@ -1,15 +1,15 @@
-from cmselemental.models.procedures import ProcOutput
-from .input import MDInput
+from cmselemental.models.procedures import OutputProc
+from .input import InputMD
 from mmelemental.models import Molecule
 from mmelemental.models.collect import Ensemble, Trajectory
 from pydantic import Field
 from typing import Optional, Dict, List
 
-__all__ = ["MDOutput"]
+__all__ = ["OutputMD"]
 
 
-class MDOutput(ProcOutput):
-    proc_input: MDInput = Field(
+class OutputMD(OutputProc):
+    proc_input: InputMD = Field(
         ..., description="Input schema used to run MD simulation"
     )
     molecule: Dict[str, Molecule] = Field(

--- a/mmic_md/models/output.py
+++ b/mmic_md/models/output.py
@@ -27,3 +27,11 @@ class OutputMD(OutputProc):
         description="Trajectory output representing a series of snapshots of the system at "
         "different timesteps. See the :class:``Trajectory`` class.",
     )
+    observable: Optional[Dict[str, List[float]]] = Field(
+        None,
+        description="Stores any observable or physical variable not accounted for in the schema. "
+        "e.g. ligand scores used in docking simulations.",
+    )
+    observable_units: Optional[Dict[str, str]] = Field(
+        None, description="Observable units. Any unit supported by pint is allowed."
+    )

--- a/mmic_md/models/output.py
+++ b/mmic_md/models/output.py
@@ -3,7 +3,7 @@ from .input import InputMD
 from mmelemental.models import Molecule
 from mmelemental.models.collect import Ensemble, Trajectory
 from pydantic import Field
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Union
 
 __all__ = ["OutputMD"]
 
@@ -12,7 +12,7 @@ class OutputMD(OutputProc):
     proc_input: InputMD = Field(
         ..., description="Input schema used to run MD simulation"
     )
-    molecule: Dict[str, Molecule] = Field(
+    molecule: Union[Molecule, List[Molecule]] = Field(
         ...,
         description="Molecular mechanics molecule object(s). See the :class:``Molecule`` class. "
         "Example: mol = {'ligand': Molecule, 'receptor': Molecule, 'solvent': Molecule}.",

--- a/mmic_md/tests/test_mmic_md.py
+++ b/mmic_md/tests/test_mmic_md.py
@@ -60,7 +60,7 @@ def test_mmic_md_models():
             return mmic_md.MDOutput
 
         @classmethod
-        def strategy_comp(cls):
+        def strategy_comps(cls):
             return mmic_md.MDComponent
 
         @classmethod

--- a/mmic_md/tests/test_mmic_md.py
+++ b/mmic_md/tests/test_mmic_md.py
@@ -6,6 +6,7 @@ Unit and regression test for the mmic_md package.
 import mmic_md
 import pytest
 from mmic.components.blueprints import TacticComponent
+from cmselemental.util.decorators import classproperty
 import mm_data
 from typing import Tuple
 import sys
@@ -28,7 +29,7 @@ def test_mmic_md_models():
     with open(ff_file, "r") as fp:
         ff = json.load(fp)
 
-    inputs = mmic_md.MDInput(
+    inputs = mmic_md.InputMD(
         molecule={"mol": mol},
         schema_name="test",
         schema_version=1.0,
@@ -46,32 +47,32 @@ def test_mmic_md_models():
         method="md",
         long_forces={"method": "PME"},
         short_forces={"method": "Cutoff"},
-       	Tcoupl_arg={"method": "Berendsen", "ref_t": 300},
-        Pcoupl_arg={"method": "no"},
+       	temp_couple={"method": "Berendsen", "ref_t": 300},
+        press_couple={"method": "no"},
     )
 
     class MDDummyComponent(TacticComponent):
-        @classmethod
+        @classproperty
         def input(cls):
-            return mmic_md.MDInput
+            return mmic_md.InputMD
 
-        @classmethod
+        @classproperty
         def output(cls):
-            return mmic_md.MDOutput
+            return mmic_md.OutputMD
 
         @classmethod
         def strategy_comps(cls):
             return mmic_md.MDComponent
 
-        @classmethod
-        def get_version(cls):
+        @classproperty
+        def version(cls):
             return None
 
         def execute(
             self,
-            inputs: mmic_md.MDInput,
-        ) -> Tuple[bool, mmic_md.MDOutput]:
+            inputs: mmic_md.InputMD,
+        ) -> Tuple[bool, mmic_md.OutputMD]:
 
-            return True, mmic_md.MDOutput(proc_input=inputs, molecule=inputs.molecule, schema_name=inputs.schema_name, schema_version=inputs.schema_version, success=True)
+            return True, mmic_md.OutputMD(proc_input=inputs, molecule=inputs.molecule, schema_name=inputs.schema_name, schema_version=inputs.schema_version, success=True)
 
     outputs = MDDummyComponent.compute(inputs)

--- a/mmic_md/tests/test_mmic_md.py
+++ b/mmic_md/tests/test_mmic_md.py
@@ -5,6 +5,7 @@ Unit and regression test for the mmic_md package.
 # Import package, test suite, and other packages as needed
 import mmic_md
 import pytest
+from mmelemental.models import Molecule, ForceField
 from mmic.components.blueprints import TacticComponent
 from cmselemental.util.decorators import classproperty
 import mm_data
@@ -24,16 +25,17 @@ def test_mmic_md_imported():
 
 def test_mmic_md_models():
     with open(mol_file, "r") as fp:
-        mol = json.load(fp)
+        mol_data = json.load(fp)
+        mol = Molecule(**mol_data) 
 
     with open(ff_file, "r") as fp:
-        ff = json.load(fp)
+        ff_data = json.load(fp)
+        ff = ForceField(**ff_data)
 
     inputs = mmic_md.InputMD(
-        molecule={"mol": mol},
         schema_name="test",
         schema_version=1.0,
-        forcefield={"mol": ff},
+        system={mol: ff},
         boundary=(
             "periodic",
             "periodic",
@@ -73,6 +75,14 @@ def test_mmic_md_models():
             inputs: mmic_md.InputMD,
         ) -> Tuple[bool, mmic_md.OutputMD]:
 
-            return True, mmic_md.OutputMD(proc_input=inputs, molecule=inputs.molecule, schema_name=inputs.schema_name, schema_version=inputs.schema_version, success=True)
+            return (
+                True, 
+                mmic_md.OutputMD(proc_input=inputs, 
+                molecule=mol, 
+                schema_name=inputs.schema_name, 
+                schema_version=inputs.schema_version, 
+                success=True,
+                ),
+            )
 
     outputs = MDDummyComponent.compute(inputs)


### PR DESCRIPTION
## Description
Since ForcesInput, a class used to store the info of long and short range forces in MD, is going to be removed, this repo is responsible for it. The class now is written into the input model with 3 simple args determined by users. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Add more necessary args to ForcesInput
  - [ ] By the same logic, another class named CouplingInput which can store info of Tcoupl and Pcoupl methods might be put into the input model

## Questions
- [ ] Is adding dielectric constant to ForcesInput necessary. Generally this cannot be set independently by users.

## Status
- [ ] Under development